### PR TITLE
[feat] 업로드 토큰 기반 인증을 도입했어요

### DIFF
--- a/src/main/java/com/gravifox/config/TimeConfig.java
+++ b/src/main/java/com/gravifox/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package com.gravifox.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/src/main/java/com/gravifox/domain/file/controller/FileController.java
+++ b/src/main/java/com/gravifox/domain/file/controller/FileController.java
@@ -1,7 +1,9 @@
 package com.gravifox.domain.file.controller;
 
 import com.gravifox.domain.file.exception.UploadException;
+import com.gravifox.domain.file.exception.UploadTokenUnauthorizedException;
 import com.gravifox.domain.file.service.FileService;
+import com.gravifox.domain.file.token.UploadAuthorizationContext;
 import com.gravifox.domain.file.util.UploadUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -37,17 +39,31 @@ public class FileController {
     )
     @PostMapping("/upload")
     public ResponseEntity<?> uploadFile(
+            @Parameter(description = "업로드 인증 토큰", required = false)
+            @RequestHeader(value = "Upload-Token", required = false) String uploadToken,
+            @Parameter(description = "Bearer 형식의 업로드 인증 토큰", required = false)
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @Parameter(description = "업로드할 이미지 파일들", required = true)
             @RequestParam("files") MultipartFile[] files) {
 
-        if(files == null || files.length == 0) {
-            throw new UploadException("Nofiles to upload");
+        UploadAuthorizationContext context = null;
+        try {
+            String tokenValue = resolveUploadToken(authorization, uploadToken);
+            context = fileService.authorizeUpload(tokenValue);
+
+            if(files == null || files.length == 0) {
+                throw new UploadException("Nofiles to upload");
+            }
+            for (MultipartFile file : files) {
+                checkFileType(file.getOriginalFilename());
+            }
+            List<String> result = uploadUtil.uplaod(files);
+            fileService.markUploadSuccess(context);
+            return ResponseEntity.ok(result);
+        } catch (RuntimeException ex) {
+            fileService.markUploadFailure(context, ex.getMessage());
+            throw ex;
         }
-        for (MultipartFile file : files) {
-            checkFileType(file.getOriginalFilename());
-        }
-        List<String> result = uploadUtil.uplaod(files);
-        return ResponseEntity.ok(result);
     }
 
     private void checkFileType(String fileName) throws UploadException {
@@ -56,5 +72,21 @@ public class FileController {
         if(!suffix.matches(regExp)) {
             throw new UploadException("Invalid file format");
         }
+    }
+
+    private String resolveUploadToken(String authorization, String uploadToken) {
+        if (uploadToken != null && !uploadToken.isBlank()) {
+            return uploadToken.trim();
+        }
+        if (authorization != null) {
+            String value = authorization.trim();
+            if (value.regionMatches(true, 0, "Bearer ", 0, 7)) {
+                String token = value.substring(7).trim();
+                if (!token.isEmpty()) {
+                    return token;
+                }
+            }
+        }
+        throw new UploadTokenUnauthorizedException("업로드 토큰이 필요해요.");
     }
 }

--- a/src/main/java/com/gravifox/domain/file/controller/UploadTokenController.java
+++ b/src/main/java/com/gravifox/domain/file/controller/UploadTokenController.java
@@ -1,0 +1,33 @@
+package com.gravifox.domain.file.controller;
+
+import com.gravifox.domain.file.token.UploadTokenService;
+import com.gravifox.domain.file.token.dto.UploadTokenIssueRequest;
+import com.gravifox.domain.file.token.dto.UploadTokenIssueResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "파일 업로드 토큰", description = "업로드용 JWT 토큰을 발급합니다.")
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("api/v1/files")
+public class UploadTokenController {
+
+    private final UploadTokenService uploadTokenService;
+
+    @Operation(summary = "업로드 토큰 발급", description = "사전 등록된 uploadId로 단일 사용 업로드 토큰을 발급합니다.")
+    @PostMapping("/upload-token")
+    public ResponseEntity<UploadTokenIssueResponse> issueUploadToken(@Valid @RequestBody UploadTokenIssueRequest request) {
+        UploadTokenService.UploadTokenIssueResult result = uploadTokenService.issueToken(request.uploadId());
+        log.debug("Issued upload token uploadId={}, jti={}", result.uploadId(), result.jti());
+        return ResponseEntity.ok(new UploadTokenIssueResponse(result.token(), result.expiresAt(), result.uploadId(), result.jti()));
+    }
+}

--- a/src/main/java/com/gravifox/domain/file/exception/UploadTokenConflictException.java
+++ b/src/main/java/com/gravifox/domain/file/exception/UploadTokenConflictException.java
@@ -1,0 +1,11 @@
+package com.gravifox.domain.file.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class UploadTokenConflictException extends RuntimeException {
+    public UploadTokenConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gravifox/domain/file/exception/UploadTokenUnauthorizedException.java
+++ b/src/main/java/com/gravifox/domain/file/exception/UploadTokenUnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.gravifox.domain.file.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UploadTokenUnauthorizedException extends RuntimeException {
+    public UploadTokenUnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gravifox/domain/file/service/FileService.java
+++ b/src/main/java/com/gravifox/domain/file/service/FileService.java
@@ -1,5 +1,12 @@
 package com.gravifox.domain.file.service;
 
+import com.gravifox.domain.file.token.UploadAuthorizationContext;
+
 public interface FileService {
-    boolean validateUserToken(String accessToken);
+
+    UploadAuthorizationContext authorizeUpload(String token);
+
+    void markUploadSuccess(UploadAuthorizationContext context);
+
+    void markUploadFailure(UploadAuthorizationContext context, String reason);
 }

--- a/src/main/java/com/gravifox/domain/file/service/impl/FileServiceImpl.java
+++ b/src/main/java/com/gravifox/domain/file/service/impl/FileServiceImpl.java
@@ -1,7 +1,8 @@
 package com.gravifox.domain.file.service.impl;
 
 import com.gravifox.domain.file.service.FileService;
-import com.gravifox.security.jwt.util.JWTUtil;
+import com.gravifox.domain.file.token.UploadAuthorizationContext;
+import com.gravifox.domain.file.token.UploadTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,11 +11,22 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Slf4j
 public class FileServiceImpl implements FileService {
-    private final JWTUtil jwtUtil;
+    private final UploadTokenService uploadTokenService;
 
     @Override
-    public boolean validateUserToken(String accessToken) {
-        log.info("Validating user token {}", jwtUtil.isValidToken.test(accessToken));
-        return jwtUtil.isValidToken.test(accessToken);
+    public UploadAuthorizationContext authorizeUpload(String token) {
+        UploadAuthorizationContext context = uploadTokenService.beginConsumption(token);
+        log.debug("Upload token authorized. uploadId={}, jti={}", context.uploadId(), context.jti());
+        return context;
+    }
+
+    @Override
+    public void markUploadSuccess(UploadAuthorizationContext context) {
+        uploadTokenService.completeSuccess(context);
+    }
+
+    @Override
+    public void markUploadFailure(UploadAuthorizationContext context, String reason) {
+        uploadTokenService.completeFailure(context, reason);
     }
 }

--- a/src/main/java/com/gravifox/domain/file/token/UploadAuthorizationContext.java
+++ b/src/main/java/com/gravifox/domain/file/token/UploadAuthorizationContext.java
@@ -1,0 +1,6 @@
+package com.gravifox.domain.file.token;
+
+import java.time.Instant;
+
+public record UploadAuthorizationContext(Long tokenId, String jti, String uploadId, Instant expiresAt) {
+}

--- a/src/main/java/com/gravifox/domain/file/token/UploadToken.java
+++ b/src/main/java/com/gravifox/domain/file/token/UploadToken.java
@@ -1,0 +1,86 @@
+package com.gravifox.domain.file.token;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "upload_tokens")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UploadToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 128)
+    private String uploadId;
+
+    @Column(nullable = false, length = 64, unique = true)
+    private String jti;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UploadTokenStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    private LocalDateTime updatedAt;
+
+    @Column(length = 255)
+    private String failureReason;
+
+    protected UploadToken(String uploadId, String jti, LocalDateTime issuedAt, LocalDateTime expiresAt) {
+        this.uploadId = uploadId;
+        this.jti = jti;
+        this.status = UploadTokenStatus.ISSUED;
+        this.issuedAt = issuedAt;
+        this.expiresAt = expiresAt;
+        this.updatedAt = issuedAt;
+    }
+
+    public static UploadToken issue(String uploadId, String jti, LocalDateTime issuedAt, LocalDateTime expiresAt) {
+        return new UploadToken(uploadId, jti, issuedAt, expiresAt);
+    }
+
+    public boolean isExpired(Clock clock) {
+        return expiresAt.isBefore(LocalDateTime.now(clock));
+    }
+
+    public void markInProgress(Clock clock) {
+        this.status = UploadTokenStatus.IN_PROGRESS;
+        this.updatedAt = LocalDateTime.now(clock);
+        this.failureReason = null;
+    }
+
+    public void markConsumed(Clock clock) {
+        this.status = UploadTokenStatus.CONSUMED;
+        this.updatedAt = LocalDateTime.now(clock);
+        this.failureReason = null;
+    }
+
+    public void markFailed(Clock clock, String reason) {
+        this.status = UploadTokenStatus.FAILED;
+        this.updatedAt = LocalDateTime.now(clock);
+        this.failureReason = reason;
+    }
+
+    public void revoke(Clock clock, String reason) {
+        this.status = UploadTokenStatus.REVOKED;
+        this.updatedAt = LocalDateTime.now(clock);
+        this.failureReason = reason;
+    }
+
+    public void touch(Clock clock) {
+        this.updatedAt = LocalDateTime.now(clock);
+    }
+}

--- a/src/main/java/com/gravifox/domain/file/token/UploadTokenRepository.java
+++ b/src/main/java/com/gravifox/domain/file/token/UploadTokenRepository.java
@@ -1,0 +1,24 @@
+package com.gravifox.domain.file.token;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface UploadTokenRepository extends JpaRepository<UploadToken, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t from UploadToken t where t.jti = :jti")
+    Optional<UploadToken> findByJtiForUpdate(@Param("jti") String jti);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t from UploadToken t where t.id = :id")
+    Optional<UploadToken> findByIdForUpdate(@Param("id") Long id);
+
+    List<UploadToken> findAllByUploadIdAndStatusIn(String uploadId, Collection<UploadTokenStatus> statuses);
+}

--- a/src/main/java/com/gravifox/domain/file/token/UploadTokenService.java
+++ b/src/main/java/com/gravifox/domain/file/token/UploadTokenService.java
@@ -1,0 +1,138 @@
+package com.gravifox.domain.file.token;
+
+import com.gravifox.domain.file.exception.UploadTokenConflictException;
+import com.gravifox.domain.file.exception.UploadTokenUnauthorizedException;
+import com.gravifox.security.jwt.service.JwtService;
+import com.gravifox.security.jwt.service.UploadTokenClaims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UploadTokenService {
+
+    private final UploadTokenRepository uploadTokenRepository;
+    private final JwtService jwtService;
+    private final Clock clock;
+
+    @Value("${jwt.upload.token-ttl-seconds:300}")
+    private long defaultTtlSeconds;
+
+    @Transactional
+    public UploadTokenIssueResult issueToken(String uploadId) {
+        if (uploadId == null || uploadId.isBlank()) {
+            throw new IllegalArgumentException("uploadId must not be blank");
+        }
+
+        Duration ttl = Duration.ofSeconds(defaultTtlSeconds);
+        Instant nowInstant = clock.instant();
+        LocalDateTime now = LocalDateTime.ofInstant(nowInstant, clock.getZone());
+        Instant expiresAtInstant = nowInstant.plus(ttl);
+        LocalDateTime expiresAt = LocalDateTime.ofInstant(expiresAtInstant, clock.getZone());
+        String jti = UUID.randomUUID().toString();
+
+        revokeActiveTokens(uploadId, "새 토큰 발급");
+
+        UploadToken entity = UploadToken.issue(uploadId, jti, now, expiresAt);
+        uploadTokenRepository.save(entity);
+
+        String token = jwtService.issueUploadToken(uploadId, jti, ttl, nowInstant);
+
+        return new UploadTokenIssueResult(token, expiresAtInstant, uploadId, jti);
+    }
+
+    @Transactional
+    public UploadAuthorizationContext beginConsumption(String token) {
+        UploadTokenClaims claims;
+        try {
+            claims = jwtService.parseUploadToken(token);
+        } catch (RuntimeException e) {
+            throw new UploadTokenUnauthorizedException("업로드 토큰 검증에 실패했어요.");
+        }
+
+        UploadToken entity = uploadTokenRepository.findByJtiForUpdate(claims.jti())
+                .orElseThrow(() -> new UploadTokenUnauthorizedException("등록된 업로드 토큰이 아니에요."));
+
+        if (!entity.getUploadId().equals(claims.uploadId())) {
+            entity.markFailed(clock, "uploadId mismatch");
+            log.warn("Upload token uploadId mismatch: expected={}, actual={}", entity.getUploadId(), claims.uploadId());
+            throw new UploadTokenUnauthorizedException("업로드 토큰 정보가 일치하지 않아요.");
+        }
+
+        if (entity.isExpired(clock)) {
+            entity.markFailed(clock, "expired");
+            throw new UploadTokenUnauthorizedException("업로드 토큰이 만료됐어요.");
+        }
+
+        if (claims.expiresAt().isBefore(clock.instant())) {
+            entity.markFailed(clock, "jwt expired");
+            throw new UploadTokenUnauthorizedException("업로드 토큰이 만료됐어요.");
+        }
+
+        if (entity.getStatus() == UploadTokenStatus.CONSUMED || entity.getStatus() == UploadTokenStatus.FAILED) {
+            throw new UploadTokenConflictException("이미 처리된 업로드 토큰이에요.");
+        }
+
+        if (entity.getStatus() != UploadTokenStatus.ISSUED) {
+            throw new UploadTokenUnauthorizedException("사용할 수 없는 업로드 토큰 상태예요.");
+        }
+
+        entity.markInProgress(clock);
+        return new UploadAuthorizationContext(entity.getId(), entity.getJti(), entity.getUploadId(), claims.expiresAt());
+    }
+
+    @Transactional
+    public void completeSuccess(UploadAuthorizationContext context) {
+        if (context == null) {
+            return;
+        }
+        uploadTokenRepository.findByIdForUpdate(context.tokenId()).ifPresent(entity -> {
+            if (entity.getStatus() == UploadTokenStatus.CONSUMED) {
+                return;
+            }
+            if (entity.getStatus() == UploadTokenStatus.IN_PROGRESS || entity.getStatus() == UploadTokenStatus.ISSUED) {
+                entity.markConsumed(clock);
+                log.debug("Upload token {} consumed successfully", entity.getJti());
+            }
+        });
+    }
+
+    @Transactional
+    public void completeFailure(UploadAuthorizationContext context, String reason) {
+        if (context == null) {
+            return;
+        }
+        uploadTokenRepository.findByIdForUpdate(context.tokenId()).ifPresent(entity -> {
+            String safeReason = (reason == null || reason.isBlank()) ? "unknown" : reason;
+            if (entity.getStatus() != UploadTokenStatus.CONSUMED) {
+                entity.markFailed(clock, safeReason);
+                log.debug("Upload token {} marked as failed: {}", entity.getJti(), safeReason);
+            }
+        });
+    }
+
+    public List<Map<String, Object>> jwks() {
+        return jwtService.jwks();
+    }
+
+    private void revokeActiveTokens(String uploadId, String reason) {
+        List<UploadToken> actives = uploadTokenRepository.findAllByUploadIdAndStatusIn(
+                uploadId, List.of(UploadTokenStatus.ISSUED, UploadTokenStatus.IN_PROGRESS)
+        );
+        actives.forEach(token -> token.revoke(clock, reason));
+    }
+
+    public record UploadTokenIssueResult(String token, Instant expiresAt, String uploadId, String jti) {}
+}

--- a/src/main/java/com/gravifox/domain/file/token/UploadTokenStatus.java
+++ b/src/main/java/com/gravifox/domain/file/token/UploadTokenStatus.java
@@ -1,0 +1,9 @@
+package com.gravifox.domain.file.token;
+
+public enum UploadTokenStatus {
+    ISSUED,
+    IN_PROGRESS,
+    CONSUMED,
+    FAILED,
+    REVOKED
+}

--- a/src/main/java/com/gravifox/domain/file/token/dto/UploadTokenIssueRequest.java
+++ b/src/main/java/com/gravifox/domain/file/token/dto/UploadTokenIssueRequest.java
@@ -1,0 +1,6 @@
+package com.gravifox.domain.file.token.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UploadTokenIssueRequest(@NotBlank String uploadId) {
+}

--- a/src/main/java/com/gravifox/domain/file/token/dto/UploadTokenIssueResponse.java
+++ b/src/main/java/com/gravifox/domain/file/token/dto/UploadTokenIssueResponse.java
@@ -1,0 +1,6 @@
+package com.gravifox.domain.file.token.dto;
+
+import java.time.Instant;
+
+public record UploadTokenIssueResponse(String token, Instant expiresAt, String uploadId, String jti) {
+}

--- a/src/main/java/com/gravifox/security/config/SecurityConfig.java
+++ b/src/main/java/com/gravifox/security/config/SecurityConfig.java
@@ -111,7 +111,7 @@ public class SecurityConfig {
         corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS"));
         corsConfiguration.setAllowedHeaders(List.of(
                 "Authorization", "Cache-Control", "Content-Type", "X-Request-ID",
-                "If-None-Match", "If-Match"
+                "If-None-Match", "If-Match", "Upload-Token"
         ));
         corsConfiguration.setAllowCredentials(true);
         corsConfiguration.setMaxAge(3600L);

--- a/src/main/java/com/gravifox/security/jwt/controller/JwksController.java
+++ b/src/main/java/com/gravifox/security/jwt/controller/JwksController.java
@@ -1,0 +1,23 @@
+package com.gravifox.security.jwt.controller;
+
+import com.gravifox.domain.file.token.UploadTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/.well-known")
+public class JwksController {
+
+    private final UploadTokenService uploadTokenService;
+
+    @GetMapping("/jwks.json")
+    public ResponseEntity<Map<String, Object>> jwks() {
+        return ResponseEntity.ok(Map.of("keys", uploadTokenService.jwks()));
+    }
+}

--- a/src/main/java/com/gravifox/security/jwt/service/JwtService.java
+++ b/src/main/java/com/gravifox/security/jwt/service/JwtService.java
@@ -1,0 +1,166 @@
+package com.gravifox.security.jwt.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.math.BigInteger;
+import java.security.*;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+
+@Service
+@Slf4j
+public class JwtService {
+
+    private final RSAPrivateKey privateKey;
+    private final RSAPublicKey publicKey;
+    private final String keyId;
+
+    public JwtService(@Value("${jwt.upload.private-key:}") String privateKeyPem,
+                      @Value("${jwt.upload.public-key:}") String publicKeyPem,
+                      @Value("${jwt.upload.key-id:}") String configuredKeyId) {
+        KeyPair keyPair = loadKeyPair(privateKeyPem, publicKeyPem);
+        this.privateKey = (RSAPrivateKey) keyPair.getPrivate();
+        this.publicKey = (RSAPublicKey) keyPair.getPublic();
+        this.keyId = resolveKeyId(configuredKeyId, publicKey);
+    }
+
+    public String issueUploadToken(String uploadId, String jti, Duration ttl, Instant issuedAt) {
+        Instant expiresAt = issuedAt.plus(ttl);
+
+        return Jwts.builder()
+                .header()
+                .add("kid", keyId)
+                .add("typ", "JWT")
+                .and()
+                .id(jti)
+                .issuer("gravifox-upload")
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiresAt))
+                .claims()
+                .add("uploadId", uploadId)
+                .add("jti", jti)
+                .and()
+                .signWith(privateKey, Jwts.SIG.RS256)
+                .compact();
+    }
+
+    public UploadTokenClaims parseUploadToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            String uploadId = claims.get("uploadId", String.class);
+            String jti = claims.get("jti", String.class);
+            Date expiration = claims.getExpiration();
+
+            if (!StringUtils.hasText(uploadId) || !StringUtils.hasText(jti) || expiration == null) {
+                throw new IllegalArgumentException("필수 클레임이 누락됐어요.");
+            }
+
+            return new UploadTokenClaims(uploadId, jti, expiration.toInstant());
+        } catch (JwtException | IllegalArgumentException e) {
+            throw e;
+        }
+    }
+
+    public List<Map<String, Object>> jwks() {
+        Map<String, Object> jwk = new LinkedHashMap<>();
+        jwk.put("kty", "RSA");
+        jwk.put("alg", "RS256");
+        jwk.put("use", "sig");
+        jwk.put("kid", keyId);
+        jwk.put("n", base64Url(publicKey.getModulus()));
+        jwk.put("e", base64Url(publicKey.getPublicExponent()));
+        return List.of(jwk);
+    }
+
+    private KeyPair loadKeyPair(String privateKeyPem, String publicKeyPem) {
+        try {
+            if (StringUtils.hasText(privateKeyPem)) {
+                RSAPrivateKey privateKey = parsePrivateKey(privateKeyPem);
+                RSAPublicKey publicKey = StringUtils.hasText(publicKeyPem)
+                        ? parsePublicKey(publicKeyPem)
+                        : derivePublicFromPrivate(privateKey);
+                return new KeyPair(publicKey, privateKey);
+            }
+
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            KeyPair pair = generator.generateKeyPair();
+            log.warn("Generated ephemeral RSA key pair for upload tokens. Provide jwt.upload.private-key to persist keys.");
+            return pair;
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Failed to initialize RSA key pair", e);
+        }
+    }
+
+    private RSAPrivateKey parsePrivateKey(String pem) throws GeneralSecurityException {
+        byte[] content = decodePem(pem);
+        try {
+            KeyFactory factory = KeyFactory.getInstance("RSA");
+            return (RSAPrivateKey) factory.generatePrivate(new PKCS8EncodedKeySpec(content));
+        } catch (InvalidKeySpecException ex) {
+            throw new IllegalStateException("지원하지 않는 RSA 개인키 형식이에요. PKCS#8 형식을 사용해주세요.", ex);
+        }
+    }
+
+    private RSAPublicKey parsePublicKey(String pem) throws GeneralSecurityException {
+        byte[] content = decodePem(pem);
+        KeyFactory factory = KeyFactory.getInstance("RSA");
+        return (RSAPublicKey) factory.generatePublic(new X509EncodedKeySpec(content));
+    }
+
+    private RSAPublicKey derivePublicFromPrivate(RSAPrivateKey privateKey) throws GeneralSecurityException {
+        if (privateKey instanceof RSAPrivateCrtKey crtKey) {
+            KeyFactory factory = KeyFactory.getInstance("RSA");
+            return (RSAPublicKey) factory.generatePublic(new RSAPublicKeySpec(crtKey.getModulus(), crtKey.getPublicExponent()));
+        }
+        throw new IllegalStateException("공개키를 찾을 수 없어요. jwt.upload.public-key를 설정해주세요.");
+    }
+
+    private byte[] decodePem(String pem) {
+        String normalized = pem.replaceAll("-----BEGIN [^-]+-----", "")
+                .replaceAll("-----END [^-]+-----", "")
+                .replaceAll("\\s", "");
+        return Base64.getDecoder().decode(normalized);
+    }
+
+    private String base64Url(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        if (bytes.length > 1 && bytes[0] == 0) {
+            bytes = Arrays.copyOfRange(bytes, 1, bytes.length);
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String resolveKeyId(String configuredKeyId, RSAPublicKey publicKey) {
+        if (StringUtils.hasText(configuredKeyId)) {
+            return configuredKeyId;
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(publicKey.getEncoded());
+            byte[] truncated = Arrays.copyOf(hash, 8);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(truncated);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 알고리즘을 찾을 수 없어요.", e);
+        }
+    }
+}

--- a/src/main/java/com/gravifox/security/jwt/service/UploadTokenClaims.java
+++ b/src/main/java/com/gravifox/security/jwt/service/UploadTokenClaims.java
@@ -1,0 +1,6 @@
+package com.gravifox.security.jwt.service;
+
+import java.time.Instant;
+
+public record UploadTokenClaims(String uploadId, String jti, Instant expiresAt) {
+}

--- a/src/main/java/com/gravifox/security/path/RequestPathMatcher.java
+++ b/src/main/java/com/gravifox/security/path/RequestPathMatcher.java
@@ -47,7 +47,7 @@ public final class RequestPathMatcher {
             "/api/analyze/models",
             "/upload",
             "/upload/**",
-            "/api/v1/files/upload"
+            "/api/.well-known/**"
     );
 
     private RequestPathMatcher() {}


### PR DESCRIPTION
## 변경 목적
- 파일 업로드 엔드포인트에 단일 사용 업로드 토큰 인증을 적용해 보안을 강화했어요.

## 주요 변경점
- `/api/v1/files/upload` 경로에 업로드 토큰 헤더를 요구하고 검증 로직을 추가했어요.
- 업로드 토큰 발급/검증용 서비스와 컨트롤러, RS256 서명 및 JWKS 엔드포인트를 만들었어요.
- 업로드 토큰 상태를 관리하는 JPA 엔티티와 리포지토리를 추가했어요.

## 테스트 결과 요약
- `./gradlew test` (DB 접속 정보 부재로 실패했어요)

## 보안·성능 고려사항
- RS256 키는 환경설정을 통해 주입하거나 기본적으로 임시 키를 생성해요.
- 토큰 사용 시 비관적 락으로 단일 사용을 보장해요.

## 관련 이슈 번호
- 없음

------
https://chatgpt.com/codex/tasks/task_e_68ea3a80d3c8832389db4ce54c3c4453