### PR TITLE
[fix] SSE 하트비트에서 닫힌 연결을 정리했어요

### DIFF
--- a/src/main/java/com/gravifox/domain/analysis/sse/HeartbeatScheduler.java
+++ b/src/main/java/com/gravifox/domain/analysis/sse/HeartbeatScheduler.java
@@ -39,8 +39,13 @@ public class HeartbeatScheduler {
         int total = 0;
         for (String jobId : sseHub.jobIds()) {
             if (sseHub.activeCount(jobId) > 0) {
-                sseHub.send(jobId, "heartbeat", hb);
-                total++;
+                try {
+                    sseHub.send(jobId, "heartbeat", hb);
+                    total++;
+                } catch (RuntimeException e) {
+                    log.debug("[Heartbeat] failed for jobId={}, cleaning up emitter", jobId, e);
+                    sseHub.complete(jobId);
+                }
             }
         }
         if (total > 0 && heartbeatSec >= 10) {

--- a/src/main/java/com/gravifox/domain/analysis/sse/SseHub.java
+++ b/src/main/java/com/gravifox/domain/analysis/sse/SseHub.java
@@ -76,7 +76,10 @@ public class SseHub {
                         .name(event)
                         .data(data, MediaType.APPLICATION_JSON);
                 emitter.send(builder);
-            } catch (IOException e) {
+            } catch (IOException | IllegalStateException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[SSE] emitter unusable for jobId={}, removing (event={})", jobId, event);
+                }
                 toRemove.add(emitter);
             }
         }


### PR DESCRIPTION
## 변경 목적
- FastAPI에서 응답을 빠르게 종료할 때 Spring SSE에서 닫힌 스트림으로 heartbeat를 전송하려다 예외가 발생하는 문제를 완화했어요.

## 주요 변경점
- `SseHub`에서 `IllegalStateException`도 감지해서 닫힌 emitter를 즉시 정리하도록 했어요.
- Heartbeat 전송 중 예외가 나면 해당 job emitter를 마무리하도록 해서 이후 불필요한 전송을 막았어요.

## 테스트 결과 요약
- `./gradlew test`를 실행해서 모든 단위 테스트가 통과했어요.

## 보안·성능 고려사항
- 닫힌 emitter를 조기에 정리해서 리소스를 조금 더 빨리 반환하도록 했어요.

## 관련 이슈 번호
- (없음)


------
https://chatgpt.com/codex/tasks/task_e_68ec9b332f2483238ff13ecaf64359ed